### PR TITLE
Multi threading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,8 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
-	$U/_test_trigger\
+	$U/_threadtest\
+	$U/_test_trigger
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)
@@ -162,7 +163,7 @@ QEMUGDB = $(shell if $(QEMU) -help | grep -q '^-gdb'; \
 	then echo "-gdb tcp::$(GDBPORT)"; \
 	else echo "-s -p $(GDBPORT)"; fi)
 ifndef CPUS
-CPUS := 3
+CPUS := 1
 endif
 
 QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 128M -smp $(CPUS) -nographic

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -109,6 +109,12 @@ int             either_copyout(int user_dst, uint64 dst, void *src, uint64 len);
 int             either_copyin(void *dst, int user_src, uint64 src, uint64 len);
 void            procdump(void);
 
+struct thread* allocthread(uint64, uint64, uint64);
+void            freethread(struct thread *t);
+void            exitthread(void);
+int             jointhread(uint id);
+void            sleepthread(int n, uint ticks0);
+
 // swtch.S
 void            swtch(struct context*, struct context*);
 

--- a/kernel/param.h
+++ b/kernel/param.h
@@ -1,6 +1,7 @@
 #define NPROC        64  // maximum number of processes
 #define NCPU          8  // maximum number of CPUs
 #define NOFILE       16  // open files per process
+#define NTHREAD       4  // maximum number of threads in each process
 #define NFILE       100  // open files per system
 #define NINODE       50  // maximum number of active i-nodes
 #define NDEV         10  // maximum major device number

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -79,7 +79,25 @@ struct trapframe {
   /* 280 */ uint64 t6;
 };
 
+enum threadstate {
+  THREAD_UNUSED,
+  THREAD_RUNNABLE,
+  THREAD_RUNNING,
+  THREAD_JOINED,
+  THREAD_SLEEPING
+};
+
 enum procstate { UNUSED, USED, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
+
+struct thread {
+  enum threadstate state;
+  struct trapframe *trapframe;
+  uint id;
+  uint join;
+  int sleep_n;
+  uint sleep_tick0;
+};
+
 
 // Per-process state
 struct proc {
@@ -104,4 +122,6 @@ struct proc {
   struct file *ofile[NOFILE];  // Open files
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
+  struct thread threads[NTHREAD];       // Array of threads belonging to the process
+  struct thread *current_thread;  // Pointer to the currently running thread
 };

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -102,6 +102,8 @@ extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
 extern uint64 sys_trigger(void);
+extern uint64 sys_thread(void);     
+extern uint64 sys_jointhread(void); 
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -128,6 +130,8 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_thread]  sys_thread,     
+[SYS_jointhread] sys_jointhread, 
 };
 
 void
@@ -135,15 +139,26 @@ syscall(void)
 {
   int num;
   struct proc *p = myproc();
+  struct thread *oldt = p->current_thread;
+  uint64 ret;
 
   num = p->trapframe->a7;
   if(num > 0 && num < NELEM(syscalls) && syscalls[num]) {
-    // Use num to lookup the system call function for num, call it,
-    // and store its return value in p->trapframe->a0
-    p->trapframe->a0 = syscalls[num]();
+    ret = syscalls[num]();
   } else {
     printf("%d %s: unknown sys call %d\n",
             p->pid, p->name, num);
-    p->trapframe->a0 = -1;
+    ret = -1;
+  }
+
+  struct thread *newt = p->current_thread;
+  
+  if (oldt != newt) {
+    if (!oldt)
+      oldt = &p->threads[0];
+    oldt->trapframe->a0 = ret;
+  }
+  if (oldt == newt || p->current_thread == oldt) {
+    p->trapframe->a0 = ret;
   }
 }

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -21,3 +21,5 @@
 #define SYS_mkdir  20
 #define SYS_close  21
 #define SYS_trigger 22
+#define SYS_thread 23      
+#define SYS_jointhread 24  

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -67,6 +67,12 @@ sys_sleep(void)
     n = 0;
   acquire(&tickslock);
   ticks0 = ticks;
+  if (myproc()->current_thread) {
+    release(&tickslock);
+    sleepthread(n, ticks0); // تابع جدید خواب برای نخ را صدا بزن
+    return 0;
+  }
+
   while(ticks - ticks0 < n){
     if(killed(myproc())){
       release(&tickslock);
@@ -98,4 +104,33 @@ sys_uptime(void)
   xticks = ticks;
   release(&tickslock);
   return xticks;
+}
+
+
+uint64
+sys_thread(void) {
+  uint64 start_thread, stack_address, arg;
+  
+  // خواندن آرگومان‌ها از فضای کاربر
+  argaddr(0, &start_thread);
+  argaddr(1, &stack_address);
+  argaddr(2, &arg);
+
+  // فراخوانی تابع اصلی برای تخصیص و ساخت نخ (این تابع را بعدا می‌نویسیم)
+  struct thread *t = allocthread(start_thread, stack_address, arg);
+
+  // اگر نخ با موفقیت ساخته شد، شناسه آن را برگردان
+  return t ? t->id : 0;
+}
+
+// تابع sys_jointhread برای پیوستن به یک نخ
+uint64
+sys_jointhread(void) {
+  int id;
+
+  // خواندن شناسه نخ مورد نظر از فضای کاربر
+  argint(0, &id);
+  
+  // فراخوانی تابع اصلی برای پیوستن به نخ (این تابع را بعدا می‌نویسیم)
+  return jointhread(id);
 }

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -67,7 +67,14 @@ usertrap(void)
     syscall();
   } else if((which_dev = devintr()) != 0){
     // ok
-  } else {
+  } else if (p->current_thread && p->current_thread->id != p->pid) {
+    // اگر یک نخ (و نه فرآیند اصلی) دچار خطا شد
+    printf("usertrap(): thread unexpected scause 0x%lx pid=%d tid=%d\n", r_scause(), p->pid, p->current_thread->id);
+    printf("            sepc=0x%lx stval=0x%lx\n", r_sepc(), r_stval());
+    exitthread(); // فقط همین نخ را خاتمه بده
+  // --- پایان تغییرات ---
+  }
+   else {
     printf("usertrap(): unexpected scause 0x%lx pid=%d\n", r_scause(), p->pid);
     printf("            sepc=0x%lx stval=0x%lx\n", r_sepc(), r_stval());
     setkilled(p);

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -33,6 +33,8 @@ trapinithart(void)
 // handle an interrupt, exception, or system call from user space.
 // called from trampoline.S
 //
+// در فایل kernel/trap.c - این نسخه کامل و صحیح usertrap است
+
 void
 usertrap(void)
 {
@@ -41,40 +43,35 @@ usertrap(void)
   if((r_sstatus() & SSTATUS_SPP) != 0)
     panic("usertrap: not from user mode");
 
-  // send interrupts and exceptions to kerneltrap(),
-  // since we're now in the kernel.
   w_stvec((uint64)kernelvec);
 
   struct proc *p = myproc();
   
-  // save user program counter.
   p->trapframe->epc = r_sepc();
   
   if(r_scause() == 8){
-    // system call
-
+    // System call
     if(killed(p))
       exit(-1);
 
-    // sepc points to the ecall instruction,
-    // but we want to return to the next instruction.
     p->trapframe->epc += 4;
-
-    // an interrupt will change sepc, scause, and sstatus,
-    // so enable only now that we're done with those registers.
     intr_on();
-
     syscall();
   } else if((which_dev = devintr()) != 0){
-    // ok
-  } else if (p->current_thread && p->current_thread->id != p->pid) {
-    // اگر یک نخ (و نه فرآیند اصلی) دچار خطا شد
-    printf("usertrap(): thread unexpected scause 0x%lx pid=%d tid=%d\n", r_scause(), p->pid, p->current_thread->id);
-    printf("            sepc=0x%lx stval=0x%lx\n", r_sepc(), r_stval());
-    exitthread(); // فقط همین نخ را خاتمه بده
-  // --- پایان تغییرات ---
-  }
-   else {
+    // Ok
+  } 
+  // --- *** شروع بخش اصلاح شده و کلیدی *** ---
+  else if (p->current_thread && p->current_thread->id != p->pid) {
+    // اگر این خطا، همان خطای مورد انتظار ما (بازگشت از تابع) بود، پیام چاپ نکن
+    if (r_sepc() != r_stval() || r_scause() != 0xc) {
+      printf("usertrap(): thread unexpected scause 0x%lx pid=%d tid=%d\n", r_scause(), p->pid, p->current_thread->id);
+      printf("            sepc=0x%lx stval=0x%lx\n", r_sepc(), r_stval());
+    }
+    // در هر صورت، نخ را خاتمه بده
+    exitthread();
+  } 
+  // --- *** پایان بخش اصلاح شده *** ---
+  else {
     printf("usertrap(): unexpected scause 0x%lx pid=%d\n", r_scause(), p->pid);
     printf("            sepc=0x%lx stval=0x%lx\n", r_sepc(), r_stval());
     setkilled(p);
@@ -83,7 +80,6 @@ usertrap(void)
   if(killed(p))
     exit(-1);
 
-  // give up the CPU if this is a timer interrupt.
   if(which_dev == 2)
     yield();
 

--- a/user/sh.c
+++ b/user/sh.c
@@ -216,7 +216,7 @@ runcmd(struct cmd *cmd)
 int
 getcmd(char *buf, int nbuf)
 {
-  write(2, "AmirAli Melika: ", 16);
+  write(2, "AmirAli Melika: ", 16); 
   memset(buf, 0, nbuf);
   gets(buf, nbuf);
   if(buf[0] == 0) // EOF

--- a/user/threadtest.c
+++ b/user/threadtest.c
@@ -1,25 +1,27 @@
-#include "../kernel/types.h"
-#include "../kernel/param.h"
-#include "../kernel/memlayout.h"
-#include "../kernel/riscv.h"
-#include "../kernel/spinlock.h"
-#include "../kernel/proc.h"
-#include "../user/user.h"
+// user/threadtest.c (نسخه صحیح و نهایی)
 
-#define STACK_SIZE 100
+#include "kernel/types.h"
+#include "user/user.h"
+
+#define STACK_SIZE  4096 // یک اندازه مناسب برای پشته
 
 void *my_thread(void *arg) {
   uint64 number = (uint64) arg;
   for (int i = 0; i < 100; ++i) {
     number++;
     printf("thread: %lu\n", number);
+    sleep(1); // یک sleep کوتاه اضافه می‌کنیم تا اجرای نخ‌ها در هم تنیده شود
   }
   return (void *) number;
 }
 
 int main(int argc, char *argv[]) {
-  int sp1[STACK_SIZE], sp2[STACK_SIZE], sp3[STACK_SIZE];
+  // پشته‌ها را با malloc تخصیص بده تا از تراز بودن آنها مطمئن شوی
+  void *sp1 = malloc(STACK_SIZE);
+  void *sp2 = malloc(STACK_SIZE);
+  void *sp3 = malloc(STACK_SIZE);
   
+  // آدرس بالای پشته را به تابع پاس بده
   int ta = thread(my_thread, sp1 + STACK_SIZE, (void *) 100);
   printf("NEW THREAD CREATED %d\n", ta);
   
@@ -33,6 +35,11 @@ int main(int argc, char *argv[]) {
   jointhread(tb);
   jointhread(tc);
   
+  // حافظه تخصیص داده شده را آزاد کن
+  free(sp1);
+  free(sp2);
+  free(sp3);
+
   printf("DONE\n");
   
   exit(0);

--- a/user/threadtest.c
+++ b/user/threadtest.c
@@ -1,0 +1,39 @@
+#include "../kernel/types.h"
+#include "../kernel/param.h"
+#include "../kernel/memlayout.h"
+#include "../kernel/riscv.h"
+#include "../kernel/spinlock.h"
+#include "../kernel/proc.h"
+#include "../user/user.h"
+
+#define STACK_SIZE 100
+
+void *my_thread(void *arg) {
+  uint64 number = (uint64) arg;
+  for (int i = 0; i < 100; ++i) {
+    number++;
+    printf("thread: %lu\n", number);
+  }
+  return (void *) number;
+}
+
+int main(int argc, char *argv[]) {
+  int sp1[STACK_SIZE], sp2[STACK_SIZE], sp3[STACK_SIZE];
+  
+  int ta = thread(my_thread, sp1 + STACK_SIZE, (void *) 100);
+  printf("NEW THREAD CREATED %d\n", ta);
+  
+  int tb = thread(my_thread, sp2 + STACK_SIZE, (void *) 200);
+  printf("NEW THREAD CREATED %d\n", tb);
+  
+  int tc = thread(my_thread, sp3 + STACK_SIZE, (void *) 300);
+  printf("NEW THREAD CREATED %d\n", tc);
+
+  jointhread(ta);
+  jointhread(tb);
+  jointhread(tc);
+  
+  printf("DONE\n");
+  
+  exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -24,6 +24,10 @@ int sleep(int);
 int uptime(void);
 int trigger(void);
 
+int thread(void *start_thread, int *stack_address, void *arg); 
+int jointhread(int id);                                      
+
+
 // ulib.c
 int stat(const char*, struct stat*);
 char* strcpy(char*, const char*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -37,3 +37,6 @@ entry("sbrk");
 entry("sleep");
 entry("uptime");
 entry("trigger");
+entry("thread");      
+entry("jointhread");    
+


### PR DESCRIPTION
This PR introduces kernel-level multi-threading support to the xv6 operating system. The implementation allows a single process to create and manage multiple threads that share the same address space.

Key Changes:

New System Calls: Added thread() to create a new thread and jointhread() to wait for a thread to terminate.

Kernel Data Structures: Modified the proc struct to manage an array of threads and defined a new thread struct to hold thread-specific state, including its own trapframe.

Scheduler Modification: The main process scheduler (scheduler) in proc.c was updated to be thread-aware. It now uses a new thread_schd function to perform round-robin scheduling among the threads of a runnable process.

Trap & System Call Handling: Updated the usertrap and syscall handlers to correctly manage thread-specific contexts, ensuring that faults in one thread do not terminate the entire process.

User-Level Test: Included a threadtest.c program to validate the new functionality by creating multiple concurrent threads and synchronizing their completion.